### PR TITLE
Add "save logs" to translatable resources

### DIFF
--- a/aroma-installer/src/aroma.h
+++ b/aroma-installer/src/aroma.h
@@ -277,6 +277,7 @@ typedef struct  {
   char  text_calibrating[32]; // Calibration Tools
   char  text_quit[32];        // Quit
   char  text_quit_msg[64];   // Quit Message
+  char  text_save_logs[32];   // Save Logs
   
   // ROM Text
   char rom_name[64];          // ROM Name

--- a/aroma-installer/src/aroma_controls.c
+++ b/aroma-installer/src/aroma_controls.c
@@ -87,6 +87,7 @@ void acfg_init_ex(byte themeonly){
     snprintf(acfg_var.text_calibrating,31,"Calibrating Tools");
     snprintf(acfg_var.text_quit,31,"Quit Installation");
     snprintf(acfg_var.text_quit_msg,63,"Are you sure to quit the installer?");
+    snprintf(acfg_var.save_logs,31,"Save Logs");
     
     snprintf(acfg_var.rom_name,63,AROMA_NAME);
     snprintf(acfg_var.rom_version,63,AROMA_VERSION);

--- a/aroma-installer/src/aroma_installer.c
+++ b/aroma-installer/src/aroma_installer.c
@@ -588,7 +588,7 @@ int aroma_start_install(
         // Show Dump Button
         acbutton(
           hWin,
-          pad,py,(cw/2)-(agdp()*2),ph,"Save Logs",0,
+          pad,py,(cw/2)-(agdp()*2),ph,acfg()->text_save_logs,0,
           8
         );
         


### PR DESCRIPTION
This tiny patch allows to translate "Save Logs" button :)
