### PR TITLE
Hungarian translation + fixes in language_select.edify

### DIFF
--- a/assets/META-INF/com/google/android/aroma/langs/hu.lang
+++ b/assets/META-INF/com/google/android/aroma/langs/hu.lang
@@ -1,0 +1,69 @@
+﻿### LICENSE:
+#
+# Copyright (C) 2011 Ahmad Amarullah ( http://amarullz.com/ )
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+### LANGUAGE STRING RESOURCE FILE
+#
+#   Language  : Hungarian (Magyar)
+#   By        : iamnotstanley (Daniel Streba)
+#
+
+#
+#--- COMMON SYSTEM STRING RESOURCE
+#
+text_ok=Oké
+text_next=Következő
+text_back=Vissza
+text_yes=Igen
+text_no=Nem
+text_about=Névjegy
+text_calibrating=Kalibrációs eszközök
+text_quit=Kilépés a telepítőből
+text_quit_msg=Biztos, hogy ki szeretnél lépni a telepítőből?
+
+#
+#-- CUSTOM STRING RESOURCE
+#
+common.for=for
+
+langtest.title=Lokalizációs teszt
+langtest.multiline=Ez a szöveg a langs/hu.lang fájlban található\
+Használj backslash-t, mielőtt enter-t nyomnál, hogy új sort adj hozzá\
+\
+Illetve tudsz <b>Formázás</b>t is a nyelvi karakterlánc forrásban..\
+\
+Köszönöm, hogy az AROMA Installer-t használod
+
+#-- End of string without any backslash for multiline text
+
+
+themes.title=Válassz témát
+themes.desc=Kérlek válaszd ki a telepítő témát, amit szeretnél használni ebben a telepítési tesztben:
+
+welcome.title=Üdvözöllek
+welcome.text1=Most ezt telepítheted:
+welcome.text2=AROMA Installer volt az első és egyetlen érintős és testreszabható Android ROM telepítő a világon.
+welcome.version=VERZIÓ
+welcome.codename=KÓDNÉV
+welcome.updated=DÁTUM
+welcome.next=Nyomj a Következőre, hogy folytasd a telepítést...
+
+terms.title=Felhasználási feltételek
+terms.desc=Kérlek figyelmesen olvasd el az AROMA Installer Felhasználási feltételeit lejjebb..
+terms.check=Egyetértek a Felhasználási feltételekkel...
+terms.confirm=Kérlek fogadd el a Felhasználási feltételeket...
+
+changelog.title=Verziótörténet
+changelog.desc=AROMA Installer Verziótörténet

--- a/assets/META-INF/com/google/android/aroma/language_select.edify
+++ b/assets/META-INF/com/google/android/aroma/language_select.edify
@@ -28,7 +28,8 @@ selectbox(
     "Italian",            "Benvenuti Installer",                                         0,      #-- selected.0 = 7
     "Germany",            "Willkommen bei Installer",                                    0,      #-- selected.0 = 8
     "Hebrew",             "ברוכים הבאים להתקנה",                                         0,      #-- selected.0 = 9
-    "Japanese",           "インストーラへよう こそ",                                                0      #-- selected.0 = 10
+    "Japanese",           "インストーラへよう こそ",                                                0,      #-- selected.0 = 10
+    "Hungarian",          "Üdvözöllek a telepítőben",                                  0      #-- selected.0 = 11
 
   #--------[ Initial Value = 0: Unselected, 1: Selected, 2: Group Item, 3: Not Visible ]---------#
 );
@@ -74,4 +75,8 @@ endif;
 
 if prop("lang.prop","selected.0")=="10" then
   loadlang("langs/ja.lang");
+endif;
+
+if prop("lang.prop","selected.0")=="11" then
+  loadlang("langs/hu.lang");
 endif;

--- a/assets/META-INF/com/google/android/aroma/language_select.edify
+++ b/assets/META-INF/com/google/android/aroma/language_select.edify
@@ -25,10 +25,11 @@ selectbox(
     "Simplified Chinesse","欢迎到安装",                                                   0,      #-- selected.0 = 4  
     "French",             "Bienvenue dans l'installateur",                               0,      #-- selected.0 = 5
     "Russian",            "Добро пожаловать в установщик",                               0,      #-- selected.0 = 6
-  	"Italian",            "Benvenuti Installer",                                         0,      #-- selected.0 = 7
-  	"Germany",            "Willkommen bei Installer",									                   0, 		 #-- selected.0 = 8
-  	"Hebrew",             "ברוכים הבאים להתקנה",										                          0		 #-- selected.0 = 9
-  	"Japanese",            "インストーラへようこそ",                               0,      #-- selected.0 = 10
+    "Italian",            "Benvenuti Installer",                                         0,      #-- selected.0 = 7
+    "Germany",            "Willkommen bei Installer",                                    0,      #-- selected.0 = 8
+    "Hebrew",             "ברוכים הבאים להתקנה",                                         0,      #-- selected.0 = 9
+    "Japanese",           "インストーラへよう こそ",                                                0      #-- selected.0 = 10
+
   #--------[ Initial Value = 0: Unselected, 1: Selected, 2: Group Item, 3: Not Visible ]---------#
 );
 
@@ -74,4 +75,3 @@ endif;
 if prop("lang.prop","selected.0")=="10" then
   loadlang("langs/ja.lang");
 endif;
-


### PR DESCRIPTION
Today I made the Hungarian translation for AROMA Installer, and while I was making it, I fixed some minor problems, and a missing colon in language_select.edify.
I can't try it now, but the syntax is correct.